### PR TITLE
Spanish translation implemented

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -7,32 +7,34 @@ description 'ESX Basic Needs'
 version '1.0.1'
 
 server_scripts {
-	'@es_extended/locale.lua',
-	'locales/de.lua',
-	'locales/br.lua',
-	'locales/en.lua',
-	'locales/fi.lua',
-	'locales/fr.lua',
-	'locales/sv.lua',
-	'locales/pl.lua',
-	'config.lua',
-	'server/main.lua'
+    '@es_extended/locale.lua',
+    'locales/de.lua',
+    'locales/br.lua',
+    'locales/en.lua',
+    'locales/es.lua',
+    'locales/fi.lua',
+    'locales/fr.lua',
+    'locales/sv.lua',
+    'locales/pl.lua',
+    'config.lua',
+    'server/main.lua'
 }
 
 client_scripts {
-	'@es_extended/locale.lua',
-	'locales/de.lua',
-	'locales/br.lua',
-	'locales/en.lua',
-	'locales/fi.lua',
-	'locales/fr.lua',
-	'locales/sv.lua',
-	'locales/pl.lua',
-	'config.lua',
-	'client/main.lua'
+    '@es_extended/locale.lua',
+    'locales/de.lua',
+    'locales/br.lua',
+    'locales/en.lua',
+    'locales/es.lua',
+    'locales/fi.lua',
+    'locales/fr.lua',
+    'locales/sv.lua',
+    'locales/pl.lua',
+    'config.lua',
+    'client/main.lua'
 }
 
 dependencies {
-	'es_extended',
-	'esx_status'
+    'es_extended',
+    'esx_status'
 }

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -1,0 +1,4 @@
+Locales['es'] = {
+  ['used_bread'] = 'Has usado ~y~1x~s~ ~b~pan~s~',
+  ['used_water'] = 'Has usado ~y~1x~s~ ~b~agua~s~',
+}

--- a/localization/es_esx_basicneeds.sql
+++ b/localization/es_esx_basicneeds.sql
@@ -1,0 +1,6 @@
+USE `es_extended`;
+
+INSERT INTO `items` (`name`, `label`, `weight`) VALUES
+    ('bread', 'Pan', 1),
+    ('water', 'Agua', 1)
+;


### PR DESCRIPTION
Spanish translation implemented in the script.

dceef2e - Created the sql `es_esx_basicneeds.sql` with the spanish translation for the database

3a8b9ad - Added the translations of the script in Spanish and fixed the spacing of fxmanifest.lua (4 spaces per tab)